### PR TITLE
Change from jsxBracketSameLine to bracketSameLine (Prettier 2.4+)

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -7,7 +7,7 @@ module.exports = {
   singleQuote: false,
   trailingComma: 'none',
   bracketSpacing: true,
-  jsxBracketSameLine: false,
+  bracketSameLine: false,
   arrowParens: 'avoid',
   rangeStart: 0,
   rangeEnd: null

--- a/lib/questions.js
+++ b/lib/questions.js
@@ -90,7 +90,7 @@ const editPropertiesOptions = [
   },
   {
     type: 'expand',
-    name: 'jsxBracketSameLine',
+    name: 'bracketSameLine',
     message: 'Put > on the last line instead of at a new line?',
     choices: [
       {
@@ -190,7 +190,7 @@ const propertiesOptions = [
     choices: [
       'arrowParens',
       'bracketSpacing',
-      'jsxBracketSameLine',
+      'bracketSameLine',
       'parser',
       'printWidth',
       'semi',


### PR DESCRIPTION
Move from deprecated jsxBracketSameLine over to bracketSameLine.  Adds support for HTML, Vue, and Angular in addition to JSX.

https://prettier.io/blog/2021/09/09/2.4.0.html

https://prettier.io/docs/en/options.html#bracket-spacing

